### PR TITLE
Add trash support and richer file properties metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Spleen is a lightweight PyQt file manager built for Hyprland.
 ## Features
 
 - Tabbed file browsing with live search filtering
-- Context menu actions: open, rename, delete, new folder, copy/move, properties and zip extraction
+- Context menu actions: open, rename, move to trash/delete, new folder, copy/move, properties and zip extraction
+- Detailed properties dialog with permissions, ownership and timestamps
 - Cut/Copy/Paste between directories
 - Automatic detection of newly mounted drives
 - Configurable default start directory saved across sessions


### PR DESCRIPTION
## Summary
- display permissions, ownership, timestamps and symlink target in Properties dialog
- support moving files to trash using `gio` or `trash-put` with fallback deletion
- add settings toggle for trash use and document new features

## Testing
- `python -m py_compile spleen.py`

------
https://chatgpt.com/codex/tasks/task_e_68a012844e9c833093d08245e936e91f